### PR TITLE
Adding externally_connectable to manifest

### DIFF
--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -33,6 +33,7 @@ icons:
   '48': images/newtab-icon-48.png
   '128': images/newtab-icon-128.png
 manifest_version: 2
+externally_connectable: {}
 web_accessible_resources:
 - fonts/ProximaNova-Reg-webfont.eot
 - fonts/ProximaNova-Reg-webfont.woff


### PR DESCRIPTION
## Goal

Fix security hole regarding external connections

## Todos:
- [x] Add external_connectable to manifest with an empty object

## Implementation Decisions
This is a security concern when using chrome-react-redux.  This make the extension unable to connect externally at this time per [https://developer.chrome.com/extensions/manifest/externally_connectable] (https://developer.chrome.com/extensions/manifest/externally_connectable)


### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?